### PR TITLE
Add logging for payment search URI in TransactionValidator

### DIFF
--- a/core-services/egov-pg-service/src/main/java/org/egov/pg/validator/TransactionValidator.java
+++ b/core-services/egov-pg-service/src/main/java/org/egov/pg/validator/TransactionValidator.java
@@ -147,6 +147,7 @@ public class TransactionValidator {
 				criteria.setTenantId(newStatus.getTenantId());
 				String uri=props.getCollectionServiceHost();
 				uri=uri.concat(props.getPaymentSearchPath());
+				log.info("uri::"+uri);
 				PaymentResponse paymentResponse=collectionsRepository.serachPaidBillInEGCL(criteria,uri);
 				log.info("paymentResponse::"+paymentResponse);
 				if(!CollectionUtils.isEmpty(paymentResponse.getPayments()))


### PR DESCRIPTION
Introduced an info log statement to output the constructed URI used for payment search in the TransactionValidator. This helps in debugging and tracking the exact endpoint being called during transaction validation.