### PR TITLE
Add logging for payment search criteria

### DIFF
--- a/core-services/egov-pg-service/src/main/java/org/egov/pg/validator/TransactionValidator.java
+++ b/core-services/egov-pg-service/src/main/java/org/egov/pg/validator/TransactionValidator.java
@@ -148,6 +148,7 @@ public class TransactionValidator {
 				String uri=props.getCollectionServiceHost();
 				uri=uri.concat(props.getPaymentSearchPath());
 				log.info("uri::"+uri);
+				log.info("criteria::"+criteria);
 				PaymentResponse paymentResponse=collectionsRepository.serachPaidBillInEGCL(criteria,uri);
 				log.info("paymentResponse::"+paymentResponse);
 				if(!CollectionUtils.isEmpty(paymentResponse.getPayments()))


### PR DESCRIPTION
Added a log statement to output the payment search criteria before invoking the collections repository. This will help in debugging and tracing the criteria used for payment searches.