### PR TITLE
Add payment count check by billId in transaction validation

### DIFF
--- a/core-services/egov-pg-service/src/main/java/org/egov/pg/repository/CollectionsRepository.java
+++ b/core-services/egov-pg-service/src/main/java/org/egov/pg/repository/CollectionsRepository.java
@@ -1,6 +1,9 @@
 package org.egov.pg.repository;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.beans.Transient;
+
 import org.egov.pg.config.AppProperties;
 import org.egov.pg.models.PaymentResponse;
 import org.egov.pg.models.PaymentSearchCriteria;
@@ -9,10 +12,13 @@ import org.egov.pg.models.ReceiptRes;
 import org.egov.tracer.model.CustomException;
 import org.egov.tracer.model.ServiceCallException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+
 
 @Repository
 @Slf4j
@@ -21,12 +27,18 @@ public class CollectionsRepository {
 
     private AppProperties appProperties;
     private RestTemplate restTemplate;
+    
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    
 
     @Autowired
     CollectionsRepository(RestTemplate restTemplate, AppProperties appProperties) {
         this.restTemplate = restTemplate;
         this.appProperties = appProperties;
     }
+    
+    
 
 
     public ReceiptRes generateReceipt(ReceiptReq receiptReq) {
@@ -75,6 +87,16 @@ public class CollectionsRepository {
             throw new CustomException("COLLECTION_SERVICE_ERROR", "Unknown error occurred during collections " +
                     "API call");
         }
+        
+    }
+    
+   public int getPaymentCountByBillId(String billId) {
+        String sql = "SELECT COUNT(*) " +
+                     "FROM egcl_payment ep " +
+                     "JOIN egcl_paymentdetail ep2 ON ep.id = ep2.paymentid " +
+                     "WHERE ep2.billid = ?";
+
+        return jdbcTemplate.queryForObject(sql, new Object[]{billId}, Integer.class);
     }
 
 


### PR DESCRIPTION
Introduced getPaymentCountByBillId in CollectionsRepository to efficiently check for existing payments by billId using a direct SQL query. Updated TransactionValidator to use this method instead of searching payments via REST, improving performance and simplifying the logic for duplicate payment validation.