### PR TITLE
Update regex patterns for paidBy and payerName fields

### DIFF
--- a/core-services/egov-pg-service/src/main/java/org/egov/pg/models/Payment.java
+++ b/core-services/egov-pg-service/src/main/java/org/egov/pg/models/Payment.java
@@ -88,7 +88,7 @@ public class Payment {
     @SafeHtml
     @Size(max=128)
     @NotNull
-    @Pattern(regexp = "^[a-zA-Z]+(([_\\-'`\\. ][a-zA-Z ])?[a-zA-Z]*)*$", message = "Invalid name. Only alphabets and special characters -, ',`, ., _")
+    @Pattern(regexp = "^[a-zA-Z]+([\\-_'`\\. ][a-zA-Z]+)*$",message = "Invalid name. Only alphabets and special characters -, ',`, ., _")
     @JsonProperty("paidBy")
     private String paidBy = null;
 
@@ -100,7 +100,7 @@ public class Payment {
 
     @SafeHtml
     @Size(max=128)
-    @Pattern(regexp = "^[a-zA-Z ]+(([_\\-'`\\. ][a-zA-Z ])?[a-zA-Z]*)*$", message = "Invalid name. Only alphabets and special characters -, ',`, ., _")
+    @Pattern(regexp = "^[a-zA-Z]+([\\-_'`\\. ][a-zA-Z]+)*$",message = "Invalid name. Only alphabets and special characters -, ',`, ., _")
     @JsonProperty("payerName")
     private String payerName = null;
 


### PR DESCRIPTION
Refined the regular expressions for the 'paidBy' and 'payerName' fields in the Payment model to improve validation. The new patterns ensure names start and end with alphabets and allow specific special characters only between alphabetic groups.