### PR TITLE
Update action mapping in property query builder

### DIFF
--- a/municipal-services/property-services/src/main/java/org/egov/pt/repository/builder/PropertyQueryBuilder.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/repository/builder/PropertyQueryBuilder.java
@@ -111,11 +111,11 @@ public class PropertyQueryBuilder {
 			+ "AND EXTRACT(EPOCH FROM CURRENT_DATE + INTERVAL '1 day' - INTERVAL '1 second') * 1000\r\n"
 			+ "GROUP BY ep.tenantid, epadd.ward_no";
 	public final static String TOTAL_MOVED_APPLICATION_COUNT_WITH_WARD = "SELECT CASE\r\n"
-			+ "    WHEN ewpv.\"action\" = 'OPEN' THEN 'OPEN'\r\n"
+			+ "    WHEN ewpv.\"action\" IN ('OPEN','SENDBACKTODOCKVERIFIER', 'SENDBACKTODOCVERIFIER') THEN 'OPEN'\r\n"
 			+ "    WHEN ewpv.\"action\" = 'VERIFY' THEN 'DOCVERIFIED'\r\n"
 			+ "    WHEN ewpv.\"action\" = 'FORWARD' THEN 'FIELDVERIFIED'\r\n"
 			+ "    WHEN ewpv.\"action\" = 'REJECT' THEN 'REJECTED'\r\n"
-			+ "    WHEN ewpv.\"action\" = 'REOPEN' THEN 'CORRECTIONPENDING'\r\n"
+			+ "    WHEN ewpv.\"action\" IN ('REOPEN','SENDBACKTOCITIZEN') THEN 'CORRECTIONPENDING'\r\n"
 			+ "    WHEN ewpv.\"action\" = 'APPROVE' THEN 'APPROVED'\r\n" + "  END AS action_st,\r\n"
 			+ "  COUNT(*) AS count,\r\n" + "  ep.tenantid, epadd.ward_no\r\n" + "FROM eg_wf_processinstance_v2 ewpv\r\n"
 			+ "JOIN eg_pt_property ep ON ep.acknowldgementnumber = ewpv.businessid\r\n"


### PR DESCRIPTION
Expanded the 'OPEN' and 'CORRECTIONPENDING' status mappings in TOTAL_MOVED_APPLICATION_COUNT_WITH_WARD to include additional workflow actions ('SENDBACKTODOCKVERIFIER', 'SENDBACKTODOCVERIFIER', and 'SENDBACKTOCITIZEN'). This ensures more accurate status categorization for property applications.