### PR TITLE
Use field @Autowired; comment out constructors

### DIFF
--- a/municipal-services/property-services/src/main/java/org/egov/pt/service/AssessmentEnrichmentService.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/service/AssessmentEnrichmentService.java
@@ -30,24 +30,26 @@ import org.springframework.util.StringUtils;
 
 @Service
 public class AssessmentEnrichmentService {
-
+	@Autowired
 	private AssessmentUtils assessmentUtils;
-
+	
+	@Autowired
 	private PropertyConfiguration config;
-
+	
+	@Autowired
 	private WorkflowService workflowService;
-
+	
+	@Autowired
 	private PropertyUtil propertyutil;
 
-	@Autowired
-	public AssessmentEnrichmentService(AssessmentUtils assessmentUtils, PropertyConfiguration config,
-			WorkflowService workflowService, PropertyUtil propertyutil) {
-
-		this.assessmentUtils = assessmentUtils;
-		this.config = config;
-		this.workflowService = workflowService;
-		this.propertyutil = propertyutil;
-	}
+	/*
+	 * @Autowired public AssessmentEnrichmentService(AssessmentUtils
+	 * assessmentUtils, PropertyConfiguration config, WorkflowService
+	 * workflowService, PropertyUtil propertyutil) {
+	 * 
+	 * this.assessmentUtils = assessmentUtils; this.config = config;
+	 * this.workflowService = workflowService; this.propertyutil = propertyutil; }
+	 */
 
 	/**
 	 * Service layer to enrich assessment object in create flow

--- a/municipal-services/property-services/src/main/java/org/egov/pt/util/AssessmentUtils.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/util/AssessmentUtils.java
@@ -17,16 +17,17 @@ import org.springframework.util.CollectionUtils;
 @Service
 public class AssessmentUtils extends CommonUtils {
 
-
+	@Autowired
     private PropertyService propertyService;
     
+	@Autowired
     private UnmaskingUtil unmaskingUtil;
 
-    @Autowired
-    public AssessmentUtils(PropertyService propertyService, UnmaskingUtil unmaskingUtil) {
-        this.propertyService = propertyService;
-        this.unmaskingUtil = unmaskingUtil;
-    }
+	/*
+	 * @Autowired public AssessmentUtils(PropertyService propertyService,
+	 * UnmaskingUtil unmaskingUtil) { this.propertyService = propertyService;
+	 * this.unmaskingUtil = unmaskingUtil; }
+	 */
 
     public Property getPropertyForAssessment(AssessmentRequest assessmentRequest){
     	


### PR DESCRIPTION
Replace constructor-based DI with field-based @Autowired in AssessmentEnrichmentService and AssessmentUtils. Added @Autowired to relevant fields (assessmentUtils, config, workflowService, propertyutil, propertyService, unmaskingUtil) and commented out the original constructors for reference. Intended to simplify bean wiring; no other logic changes introduced.